### PR TITLE
first attempt to fix the app using unprotected_urls instead of unprotected_regex

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -90,7 +90,8 @@ sudo service nginx restart
 
 # SSOwat unprotected regex
 
-regex="$domain/%.well%-known/acme%-challenge/.*$"
+regex="$domain/.well-known/acme-challenge"
+
 regexList=$(sudo yunohost app setting $app unprotected_regex)
 if [[ $regexList == "" ]]
 then
@@ -98,7 +99,8 @@ then
 else
     regexList="$regexList,$regex"
 fi
-sudo yunohost app setting $app unprotected_regex -v "$regexList"
+
+sudo yunohost app setting $app unprotected_urls -v "$regexList"
 sudo yunohost app ssowatconf
 
 ####################################################


### PR DESCRIPTION
Hello,

This is an half-ass finished PR because I'm not knowledgeable in this app to finish completely but that it seems better to have already a bit of the job done that nothing at all.

So, I've been debugging the installation of this application of the YunoHost instance of a friend and the installation was failing because LE could not access the domains because it was redirected to the SSO.

Following this [topic](https://forum.yunohost.org/t/how-to-install-let-s-encrypt-certificates/1075) I have the idea of using unprotected_urls instead of unprotected_regex and it fixed the issue (and seems more simple).

This PR is how I've fixed it but it really looks liked a bit more work is needed to fix that since this isn't integrated in the if/else block following it.

The problem is that I'm not using this application and that I don't have a good setup to test it so I'm not in a good position to finish it :/
